### PR TITLE
Allow Blank Strings or Nil on Optional Fields

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
 
 #################### Gemspec ##########################
 
-Gemspec/DateAssignment:
+Gemspec/DeprecatedAttributeAssignment:
   Enabled: false
 Gemspec/DuplicatedAssignment:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Example usage:
 ```ruby
 # Initialise a credit batch
 credit_batch = MT9.batch_credits(
-  account_number: "224444777777722", # Must be 15 digits
+  account_number: "224444777777722",  # Must be 15 digits
   due_date: Date.parse("4/5/2020"),
   client_short_name: "ACME Pty Ltd",  # Optional, highly recommended to fill
 )

--- a/lib/mt9/validators/base_contract.rb
+++ b/lib/mt9/validators/base_contract.rb
@@ -3,15 +3,15 @@
 module MT9
   module Validators
     class BaseContract < Dry::Validation::Contract
-      ALLOWED_ALPHANUMERIC_CHARS = /^[\w\(\+\$\*\!\)\;\-\/\?\:\'\"\=\&\<\>\.\,\%\_\#\@\ ]*$/.freeze
-
       register_macro(:is_account_number?) do
         key.failure("must be 15 or 16 numeric characters") unless value =~ /^\d{15,16}$/
         key.failure("must not start with a reserved bank code") if value.start_with?(*Values::RESERVED_BANK_CODES)
       end
 
       register_macro(:only_valid_characters?) do
-        key.failure("must not contain invalid characters") unless value.nil? || value =~ ALLOWED_ALPHANUMERIC_CHARS
+        unless value.nil? || value =~ Values::ALLOWED_ALPHANUMERIC_CHARS
+          key.failure("must not contain invalid characters")
+        end
       end
     end
   end

--- a/lib/mt9/validators/detail_record_contract.rb
+++ b/lib/mt9/validators/detail_record_contract.rb
@@ -9,14 +9,14 @@ module MT9
         required(:this_party).schema do
           required(:name).filled(:string)
           required(:code).filled(:string)
-          optional(:alpha_reference).filled(:string)
-          optional(:particulars).filled(:string)
+          optional(:alpha_reference).maybe(:string)
+          optional(:particulars).maybe(:string)
         end
         required(:other_party).schema do
           required(:name).filled(:string)
-          optional(:code).filled(:string)
-          optional(:alpha_reference).filled(:string)
-          optional(:particulars).filled(:string)
+          optional(:code).maybe(:string)
+          optional(:alpha_reference).maybe(:string)
+          optional(:particulars).maybe(:string)
         end
         required(:amount).filled(:integer, lteq?: Values::MAX_AMOUNT, gt?: 0)
       end

--- a/lib/mt9/validators/header_record_contract.rb
+++ b/lib/mt9/validators/header_record_contract.rb
@@ -7,7 +7,7 @@ module MT9
         required(:file_type).filled(:string, included_in?: Values::FILE_TYPES)
         required(:account_number).filled(:string, size?: 15) # Only 2 digit suffix allowed
         required(:due_date).filled(:date)
-        optional(:client_short_name).value(:string, size?: 0..20)
+        optional(:client_short_name).maybe(:string, size?: 0..20)
       end
 
       rule(:account_number).validate(:is_account_number?)

--- a/lib/mt9/values.rb
+++ b/lib/mt9/values.rb
@@ -14,5 +14,7 @@ module MT9
     ALL_TRANSACTION_CODES = (DEBIT_TRANSACTION_CODES | CREDIT_TRANSACTION_CODES).freeze
 
     MAX_AMOUNT = 9_999_999_999 # Due to detail record amount and trailer record total_amount only allowing 10 digits
+
+    ALLOWED_ALPHANUMERIC_CHARS = /^[\w\(\+\$\*\!\)\;\-\/\?\:\'\"\=\&\<\>\.\,\%\_\#\@\ ]*$/.freeze
   end
 end

--- a/spec/lib/mt9/detail_record_spec.rb
+++ b/spec/lib/mt9/detail_record_spec.rb
@@ -10,24 +10,30 @@ RSpec.describe MT9::DetailRecord do
       account_number: account_number,
       transaction_code: transaction_code,
       amount: amount,
-      this_party: {
-        name: "This Party",
-        code: "1234",
-        alpha_reference: "alpha_ref",
-        particulars: "particulars",
-      },
-      other_party: {
-        name: "Other Party Name, of long length",
-        code: "3219876543210",
-        alpha_reference: "other_alpha_ref",
-        particulars: "other_particulars",
-      },
+      this_party: this_party,
+      other_party: other_party,
     }
   end
 
   let(:account_number) { "123113000214598" }
   let(:transaction_code) { "052" }
   let(:amount) { 1000 }
+  let(:this_party) do
+    {
+      name: "This Party",
+      code: "1234",
+      alpha_reference: "alpha_ref",
+      particulars: "particulars",
+    }
+  end
+  let(:other_party) do
+    {
+      name: "Other Party Name, of long length",
+      code: "3219876543210",
+      alpha_reference: "other_alpha_ref",
+      particulars: "other_particulars",
+    }
+  end
 
   describe "#generate" do
     context "with full account number" do
@@ -59,6 +65,60 @@ RSpec.describe MT9::DetailRecord do
         expect(detail_record.generate).to include(
           "13123113000214598 0520000000001This Party          000000000000"\
           "1234        alpha_ref   particulars  Other Party Name, of321987654321other_alpha_other_partic    \r\n",
+        )
+      end
+    end
+
+    context "when optional fields are blank" do
+      let(:this_party) do
+        {
+          name: "This Party",
+          code: "1234",
+          alpha_reference: "",
+          particulars: "",
+        }
+      end
+
+      let(:other_party) do
+        {
+          name: "Other Party Name, of long length",
+          code: "",
+          alpha_reference: "",
+          particulars: "",
+        }
+      end
+
+      it "outputs correct row data" do
+        expect(detail_record.generate).to include(
+          "13123113000214598 0520000001000This Party          000000000000"\
+          "1234                                 Other Party Name, of                                        \r\n",
+        )
+      end
+    end
+
+    context "when optional fields are nil" do
+      let(:this_party) do
+        {
+          name: "This Party",
+          code: "1234",
+          alpha_reference: nil,
+          particulars: nil,
+        }
+      end
+
+      let(:other_party) do
+        {
+          name: "Other Party Name, of long length",
+          code: nil,
+          alpha_reference: nil,
+          particulars: nil,
+        }
+      end
+
+      it "outputs correct row data" do
+        expect(detail_record.generate).to include(
+          "13123113000214598 0520000001000This Party          000000000000"\
+          "1234                                 Other Party Name, of                                        \r\n",
         )
       end
     end

--- a/spec/lib/mt9/header_record_spec.rb
+++ b/spec/lib/mt9/header_record_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe MT9::HeaderRecord do
       end
     end
 
+    context "with a nil client short name" do
+      let(:client_short_name) { nil }
+
+      it "creates correctly formatted string" do
+        expect(result).to eq("12123456789012345 20201225                                                              "\
+          "                                                                        \r\n")
+      end
+    end
+
     context "with invalid header record args" do
       let(:account_number) { "1231231243123" }
 

--- a/spec/lib/mt9/validators/detail_record_contract_spec.rb
+++ b/spec/lib/mt9/validators/detail_record_contract_spec.rb
@@ -7,19 +7,27 @@ RSpec.describe MT9::Validators::DetailRecordContract do
     {
       account_number: "123456789012345",
       transaction_code: "052",
-      this_party: {
-        name: "This Name",
-        code: "This Code",
-        alpha_reference: "This Alpha",
-        particulars: "This Particulars",
-      },
-      other_party: {
-        name: "Other Name",
-        code: "Other Code",
-        alpha_reference: "Other Alpha",
-        particulars: "Other Particulars",
-      },
+      this_party: this_party,
+      other_party: other_party,
       amount: 1000,
+    }
+  end
+
+  let(:this_party) do
+    {
+      name: "This Name",
+      code: "This Code",
+      alpha_reference: "This Alpha",
+      particulars: "This Particulars",
+    }
+  end
+
+  let(:other_party) do
+    {
+      name: "Other Name",
+      code: "Other Code",
+      alpha_reference: "Other Alpha",
+      particulars: "Other Particulars",
     }
   end
 
@@ -55,6 +63,67 @@ RSpec.describe MT9::Validators::DetailRecordContract do
           expect(result.errors[party][field]).to eq(["must not contain invalid characters"])
         end
       end
+    end
+
+    context "when optional fields are omitted" do
+      let(:this_party) do
+        {
+          name: "This Name",
+          code: "This Code",
+        }
+      end
+
+      let(:other_party) do
+        {
+          name: "Other Name",
+        }
+      end
+
+      it { is_expected.to be_success }
+    end
+
+    context "when optional fields are nil" do
+      let(:this_party) do
+        {
+          name: "This Name",
+          code: "This Code",
+          alpha_reference: nil,
+          particulars: nil,
+        }
+      end
+
+      let(:other_party) do
+        {
+          name: "Other Name",
+          code: nil,
+          alpha_reference: nil,
+          particulars: nil,
+        }
+      end
+
+      it { is_expected.to be_success }
+    end
+
+    context "when optional fields are blank" do
+      let(:this_party) do
+        {
+          name: "This Name",
+          code: "This Code",
+          alpha_reference: "",
+          particulars: "",
+        }
+      end
+
+      let(:other_party) do
+        {
+          name: "Other Name",
+          code: "",
+          alpha_reference: "",
+          particulars: "",
+        }
+      end
+
+      it { is_expected.to be_success }
     end
 
     it "validates amount is integer" do

--- a/spec/lib/mt9/validators/header_record_contract_spec.rb
+++ b/spec/lib/mt9/validators/header_record_contract_spec.rb
@@ -16,6 +16,16 @@ RSpec.describe MT9::Validators::HeaderRecordContract do
     expect(result).to be_success
   end
 
+  it "validates a correct header record with a blank client short name" do
+    header_record[:client_short_name] = ""
+    expect(result).to be_success
+  end
+
+  it "validates a correct header record with a nil client short name" do
+    header_record[:client_short_name] = nil
+    expect(result).to be_success
+  end
+
   it "validates a correct header record with no client short name" do
     header_record.delete(:client_short_name)
     expect(result).to be_success
@@ -55,11 +65,6 @@ RSpec.describe MT9::Validators::HeaderRecordContract do
     it "validates a client short name with invalid characters" do
       header_record[:client_short_name] = "ACME | ^ [{}]"
       expect(result.errors[:client_short_name]).to eq(["must not contain invalid characters"])
-    end
-
-    it "validates a nil client short name" do
-      header_record[:client_short_name] = nil
-      expect(result.errors[:client_short_name]).to eq(["must be a string"])
     end
   end
 end


### PR DESCRIPTION
On optional fields, such as client short name on header records, or this party's alpha reference/particulars, we should allow a blank string or nil, as this allows for simpler use of the gem when trying to generate a batch with optional content.

E.g.
```ruby
batch.add_transaction(
  account_number: ...,
  this_party: {
    particulars: txn.description # txn.description could also be nil
```

This PR also moves the `ALLOWED_ALPHANUMERIC_CHARS` into the values class to allow for easier access