### PR TITLE
Add Size Constraint on Fields in Detail Record Contract

### DIFF
--- a/lib/mt9/validators/detail_record_contract.rb
+++ b/lib/mt9/validators/detail_record_contract.rb
@@ -7,16 +7,16 @@ module MT9
         required(:account_number).filled(:string)
         required(:transaction_code).filled(:string, included_in?: Values::ALL_TRANSACTION_CODES)
         required(:this_party).schema do
-          required(:name).filled(:string)
-          required(:code).filled(:string)
-          optional(:alpha_reference).maybe(:string)
-          optional(:particulars).maybe(:string)
+          required(:name).filled(:string, max_size?: 20)
+          required(:code).filled(:string, max_size?: 12)
+          optional(:alpha_reference).maybe(:string, max_size?: 12)
+          optional(:particulars).maybe(:string, max_size?: 12)
         end
         required(:other_party).schema do
-          required(:name).filled(:string)
-          optional(:code).maybe(:string)
-          optional(:alpha_reference).maybe(:string)
-          optional(:particulars).maybe(:string)
+          required(:name).filled(:string, max_size?: 20)
+          optional(:code).maybe(:string, max_size?: 12)
+          optional(:alpha_reference).maybe(:string, max_size?: 12)
+          optional(:particulars).maybe(:string, max_size?: 12)
         end
         required(:amount).filled(:integer, lteq?: Values::MAX_AMOUNT, gt?: 0)
       end

--- a/lib/mt9/validators/header_record_contract.rb
+++ b/lib/mt9/validators/header_record_contract.rb
@@ -7,7 +7,7 @@ module MT9
         required(:file_type).filled(:string, included_in?: Values::FILE_TYPES)
         required(:account_number).filled(:string, size?: 15) # Only 2 digit suffix allowed
         required(:due_date).filled(:date)
-        optional(:client_short_name).maybe(:string, size?: 0..20)
+        optional(:client_short_name).maybe(:string, max_size?: 20)
       end
 
       rule(:account_number).validate(:is_account_number?)

--- a/spec/lib/mt9/credit_batch_spec.rb
+++ b/spec/lib/mt9/credit_batch_spec.rb
@@ -32,13 +32,13 @@ RSpec.describe MT9::CreditBatch do
         name: "This Name",
         code: "This Code",
         alpha_reference: "This Alpha",
-        particulars: "This Particulars",
+        particulars: "This Particulars"[0...12],
       },
       other_party: {
         name: "Other Name",
         code: "Other Code",
         alpha_reference: "Other Alpha",
-        particulars: "Other Particulars",
+        particulars: "Other Particulars"[0...12],
       },
     }
   end

--- a/spec/lib/mt9/credit_batch_spec.rb
+++ b/spec/lib/mt9/credit_batch_spec.rb
@@ -32,13 +32,13 @@ RSpec.describe MT9::CreditBatch do
         name: "This Name",
         code: "This Code",
         alpha_reference: "This Alpha",
-        particulars: "This Particulars"[0...12],
+        particulars: "This Particu",
       },
       other_party: {
         name: "Other Name",
         code: "Other Code",
         alpha_reference: "Other Alpha",
-        particulars: "Other Particulars"[0...12],
+        particulars: "Other Partic",
       },
     }
   end

--- a/spec/lib/mt9/debit_batch_spec.rb
+++ b/spec/lib/mt9/debit_batch_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe MT9::DebitBatch do
         name: "This Name",
         code: "This Code",
         alpha_reference: "This Alpha",
-        particulars: "This Particulars"[0...12],
+        particulars: "This Particu",
       },
       other_party: {
         name: "Other Name",
         code: "Other Code",
         alpha_reference: "Other Alpha",
-        particulars: "Other Particulars"[0...12],
+        particulars: "Other Partic",
       },
     }
   end

--- a/spec/lib/mt9/debit_batch_spec.rb
+++ b/spec/lib/mt9/debit_batch_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe MT9::DebitBatch do
         name: "This Name",
         code: "This Code",
         alpha_reference: "This Alpha",
-        particulars: "This Particulars",
+        particulars: "This Particulars"[0...12],
       },
       other_party: {
         name: "Other Name",
         code: "Other Code",
         alpha_reference: "Other Alpha",
-        particulars: "Other Particulars",
+        particulars: "Other Particulars"[0...12],
       },
     }
   end

--- a/spec/lib/mt9/detail_record_spec.rb
+++ b/spec/lib/mt9/detail_record_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe MT9::DetailRecord do
   end
   let(:other_party) do
     {
-      name: "Other Party Name, of long length"[0...20],
+      name: "Other Party Name, of",
       code: "321987654321",
-      alpha_reference: "other_alpha_ref"[0...12],
-      particulars: "other_particulars"[0...12],
+      alpha_reference: "other_alpha_",
+      particulars: "other_partic",
     }
   end
 
@@ -81,7 +81,7 @@ RSpec.describe MT9::DetailRecord do
 
       let(:other_party) do
         {
-          name: "Other Party Name, of long length"[0...20],
+          name: "Other Party Name, of",
           code: "",
           alpha_reference: "",
           particulars: "",
@@ -108,7 +108,7 @@ RSpec.describe MT9::DetailRecord do
 
       let(:other_party) do
         {
-          name: "Other Party Name, of long length"[0...20],
+          name: "Other Party Name, of",
           code: nil,
           alpha_reference: nil,
           particulars: nil,

--- a/spec/lib/mt9/detail_record_spec.rb
+++ b/spec/lib/mt9/detail_record_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe MT9::DetailRecord do
   end
   let(:other_party) do
     {
-      name: "Other Party Name, of long length",
-      code: "3219876543210",
-      alpha_reference: "other_alpha_ref",
-      particulars: "other_particulars",
+      name: "Other Party Name, of long length"[0...20],
+      code: "321987654321",
+      alpha_reference: "other_alpha_ref"[0...12],
+      particulars: "other_particulars"[0...12],
     }
   end
 
@@ -81,7 +81,7 @@ RSpec.describe MT9::DetailRecord do
 
       let(:other_party) do
         {
-          name: "Other Party Name, of long length",
+          name: "Other Party Name, of long length"[0...20],
           code: "",
           alpha_reference: "",
           particulars: "",
@@ -108,7 +108,7 @@ RSpec.describe MT9::DetailRecord do
 
       let(:other_party) do
         {
-          name: "Other Party Name, of long length",
+          name: "Other Party Name, of long length"[0...20],
           code: nil,
           alpha_reference: nil,
           particulars: nil,

--- a/spec/lib/mt9/validators/detail_record_contract_spec.rb
+++ b/spec/lib/mt9/validators/detail_record_contract_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe MT9::Validators::DetailRecordContract do
       name: "This Name",
       code: "This Code",
       alpha_reference: "This Alpha",
-      particulars: "This Particulars",
+      particulars: "This Particulars"[0...12],
     }
   end
 
@@ -27,7 +27,7 @@ RSpec.describe MT9::Validators::DetailRecordContract do
       name: "Other Name",
       code: "Other Code",
       alpha_reference: "Other Alpha",
-      particulars: "Other Particulars",
+      particulars: "Other Particulars"[0...12],
     }
   end
 
@@ -59,8 +59,22 @@ RSpec.describe MT9::Validators::DetailRecordContract do
     %i[this_party other_party].each do |party|
       %i[name code alpha_reference particulars].each do |field|
         it "is invalid when #{party} #{field} contains invalid characters" do
-          detail_record[party][field] = "ACME | ^ [{}]"
+          detail_record[party][field] = "ACM | ^ [{}]"
           expect(result.errors[party][field]).to eq(["must not contain invalid characters"])
+        end
+      end
+
+      %i[name].each do |field|
+        it "is invalid when #{party} #{field} contains more than 20 characters" do
+          detail_record[party][field] = "This is more than twenty characters"
+          expect(result.errors[party][field]).to eq(["size cannot be greater than 20"])
+        end
+      end
+
+      %i[code alpha_reference particulars].each do |field|
+        it "is invalid when #{party} #{field} contains more than 12 characters" do
+          detail_record[party][field] = "This is more than twelve characters"
+          expect(result.errors[party][field]).to eq(["size cannot be greater than 12"])
         end
       end
     end

--- a/spec/lib/mt9/validators/detail_record_contract_spec.rb
+++ b/spec/lib/mt9/validators/detail_record_contract_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe MT9::Validators::DetailRecordContract do
       name: "This Name",
       code: "This Code",
       alpha_reference: "This Alpha",
-      particulars: "This Particulars"[0...12],
+      particulars: "This Particu",
     }
   end
 
@@ -27,7 +27,7 @@ RSpec.describe MT9::Validators::DetailRecordContract do
       name: "Other Name",
       code: "Other Code",
       alpha_reference: "Other Alpha",
-      particulars: "Other Particulars"[0...12],
+      particulars: "Other Partic",
     }
   end
 

--- a/spec/lib/mt9/validators/header_record_contract_spec.rb
+++ b/spec/lib/mt9/validators/header_record_contract_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe MT9::Validators::HeaderRecordContract do
 
     it "validates a long client short name" do
       header_record[:client_short_name] = "ACME Transactions and Payments Proprietary Limited"
-      expect(result.errors[:client_short_name]).to eq(["length must be within 0 - 20"])
+      expect(result.errors[:client_short_name]).to eq(["size cannot be greater than 20"])
     end
 
     it "validates a client short name with invalid characters" do


### PR DESCRIPTION
Currently we allow any input size on fields in such as `this_party.name` or `this_party.particulars`. This is fine as Fixy will truncate to the correct length for the field (20 for `name`, 12 for other fields) but this might be confusing to a user of this gem, as they wouldn't know about the maximum length of fields.

This PR adds a size constraint onto the detail record fields.

Also change the size predicate on the `client_short_name` on the header contract to stay consistent