### PR TITLE
Construct pattern with string of allowed chars

### DIFF
--- a/lib/mt9/validators/base_contract.rb
+++ b/lib/mt9/validators/base_contract.rb
@@ -9,7 +9,7 @@ module MT9
       end
 
       register_macro(:only_valid_characters?) do
-        unless value.nil? || value =~ Values::ALLOWED_ALPHANUMERIC_CHARS
+        unless value.nil? || value =~ Values::ALLOWED_CHARS_PATTERN
           key.failure("must not contain invalid characters")
         end
       end

--- a/lib/mt9/values.rb
+++ b/lib/mt9/values.rb
@@ -10,7 +10,8 @@ module MT9
     DIRECT_DEBIT = "20"
     FILE_TYPES = [DIRECT_CREDIT, DIRECT_DEBIT].freeze
 
-    ALLOWED_ALPHANUMERIC_CHARS = /^[\w\(\+\$\*\!\)\;\-\/\?\:\'\"\=\&\<\>\.\,\%\_\#\@\ ]*$/.freeze
+    ALLOWED_CHARS = %q(0-9a-zA-Z_+-@$!%&*./#=:;?,'"()<> )
+    ALLOWED_CHARS_PATTERN = /\A[#{ALLOWED_CHARS}]*\z/
     DETAIL_FIELD_MAX_LENGTH = 12
     DETAIL_RECORD_TYPE = "13"
     MAX_AMOUNT = 9_999_999_999 # Due to detail record amount and trailer record total_amount only allowing 10 digits

--- a/lib/mt9/values.rb
+++ b/lib/mt9/values.rb
@@ -11,7 +11,7 @@ module MT9
     FILE_TYPES = [DIRECT_CREDIT, DIRECT_DEBIT].freeze
 
     ALLOWED_CHARS = %q(0-9a-zA-Z_+-@$!%&*./#=:;?,'"()<> )
-    ALLOWED_CHARS_PATTERN = /\A[#{ALLOWED_CHARS}]*\z/
+    ALLOWED_CHARS_PATTERN = /\A[#{ALLOWED_CHARS}]*\z/.freeze
     DETAIL_FIELD_MAX_LENGTH = 12
     DETAIL_RECORD_TYPE = "13"
     MAX_AMOUNT = 9_999_999_999 # Due to detail record amount and trailer record total_amount only allowing 10 digits


### PR DESCRIPTION
Allows consumers of the gem to reference the string of allowed characters for validation.