### PR TITLE
Rearrange ALLOWED_CHARS to avoid quirks with symbols

### DIFF
--- a/lib/mt9/values.rb
+++ b/lib/mt9/values.rb
@@ -10,7 +10,7 @@ module MT9
     DIRECT_DEBIT = "20"
     FILE_TYPES = [DIRECT_CREDIT, DIRECT_DEBIT].freeze
 
-    ALLOWED_CHARS = %q(0-9a-zA-Z_+-@$!%&*./#=:?,'"()<> )
+    ALLOWED_CHARS = %q(0-9a-zA-Z_@$!%&*./#=:?,'"()<> +-)
     ALLOWED_CHARS_PATTERN = /\A[#{ALLOWED_CHARS}]*\z/.freeze
     DETAIL_FIELD_MAX_LENGTH = 12
     DETAIL_RECORD_TYPE = "13"


### PR DESCRIPTION
The hyphen symbol has interpreted as a character range when nested between other characters. We could have escaped it in the string literal but I'd rather have no escaping in the string (that's why we're using `%q()`) since it is easier to read so instead we move the hyphen symbol to the very end and it will be interpreted as a hyphen literal.