### PR TITLE
Fix ambiguous integer conversion when totalling hash

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,8 +12,6 @@ AllCops:
 
 #################### Gemspec ##########################
 
-Gemspec/DeprecatedAttributeAssignment:
-  Enabled: false
 Gemspec/DuplicatedAssignment:
   Enabled: false
 Gemspec/OrderedDependencies:

--- a/lib/mt9/batch.rb
+++ b/lib/mt9/batch.rb
@@ -31,7 +31,7 @@ module MT9
       @total_amount += transaction_args[:amount]
 
       # Hash total is sum of branch and unique number components of account number
-      @hash_total += Integer(transaction_args[:account_number][2..12])
+      @hash_total += Integer(transaction_args[:account_number][2..12], 10)
 
       @detail_records << detail_record
     end

--- a/spec/fixtures/mt9_direct_credits.txt
+++ b/spec/fixtures/mt9_direct_credits.txt
@@ -1,4 +1,4 @@
 12224444777777722 20200504     ACME Pty Ltd                                                                                                                     
 13123456789012345 0510000001000This Name           000000000000This Code                            ACME Pty Ltd                                                
 1311000012345678900520000005000This Name           000000000000This Code   This Alpha  This Particu Other Name          Other Code  Other Alpha Other Partic    
-139934568232514      0000006000                                                                                                                                 
+139934569124690      0000006000                                                                                                                                 

--- a/spec/fixtures/mt9_direct_debits.txt
+++ b/spec/fixtures/mt9_direct_debits.txt
@@ -1,4 +1,4 @@
 20224444777777722 20200504     ACME Pty Ltd                                                                                                                     
 13123456789012345 0000000001000This Name           000000000000This Code                            ACME Pty Ltd                                                
 1311000012345678900000000005000This Name           000000000000This Code   This Alpha  This Particu Other Name          Other Code  Other Alpha Other Partic    
-139934568232514      0000006000                                                                                                                                 
+139934569124690      0000006000                                                                                                                                 

--- a/spec/lib/mt9/credit_batch_spec.rb
+++ b/spec/lib/mt9/credit_batch_spec.rb
@@ -121,9 +121,7 @@ RSpec.describe MT9::CreditBatch do
     end
 
     it "hash total should be sum of branch and unique numbers from each transaction" do
-      expect(batch.hash_total).to eq(
-        Integer(transaction1_args[:account_number][2..12]) + Integer(transaction2_args[:account_number][2..12]),
-      )
+      expect(batch.hash_total).to eq(34_569_124_690)
     end
 
     describe "#generate" do


### PR DESCRIPTION
Integer conversion was ambiguous especially with numbers with leading zeros:

```ruby
Integer("1100001234567890"[2..12])
=> 342391
```

Adding the base arg should fix any ambiguity when totalling the hash.

Note: Don't know how Rubocop wasn't picking this up.