### PR TITLE
Update dry-validation dependency

### DIFF
--- a/mt9.gemspec
+++ b/mt9.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "dry-validation", "~> 1.8.0"
+  spec.add_dependency "dry-validation", "~> 1.10.0"
   spec.add_dependency "fixy", "~> 0.0.9"
 
   spec.add_development_dependency "pry-byebug", "~> 3.9.0"


### PR DESCRIPTION
[Changelog](https://github.com/dry-rb/dry-validation/blob/main/CHANGELOG.md#1100-2022-11-04) for dry-validation.

Supports lib users upgrading to dry-core 1.0 and dry-configurable 1.0 🎉